### PR TITLE
Pass correct arguments to browse-kill-ring-setup

### DIFF
--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -896,6 +896,7 @@ directly; use `browse-kill-ring' instead.
   ;; The user might have rearranged the windows
   (when (eq major-mode 'browse-kill-ring-mode)
     (browse-kill-ring-setup (current-buffer)
+                            browse-kill-ring-original-buffer
                             browse-kill-ring-original-window
                             nil
                             browse-kill-ring-original-window-config)


### PR DESCRIPTION
This fixes issue #8.
