### PR TITLE
Allow the preview to be turned off.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-08-15 Andrew Burgess <andrew.burgess@embecosm.com>
+	(browse-kill-ring-setup) Don't access
+	browse-kill-ring-preview-overlay, or use
+	browse-kill-ring-preview-update when preview is turned off.
+
 2014-08-07 Andrew Burgess <andrew.burgess@embecosm.com>
 	Handle case where kill-ring-yank-pointer is nil (empty kill ring).
 

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -930,9 +930,9 @@ directly; use `browse-kill-ring' instead.
         (when browse-kill-ring-preview-overlay
           (delete-overlay browse-kill-ring-preview-overlay))
         (setq browse-kill-ring-preview-overlay
-              (make-overlay start end orig-buf)))))
-  (overlay-put browse-kill-ring-preview-overlay
-               'invisible t)
+              (make-overlay start end orig-buf))
+        (overlay-put browse-kill-ring-preview-overlay
+                     'invisible t))))
   (with-current-buffer kill-buf
     (unwind-protect
         (progn
@@ -978,10 +978,12 @@ directly; use `browse-kill-ring' instead.
                          (error "Invalid `browse-kill-ring-display-style': %s"
                                 browse-kill-ring-display-style))
                      items)
-            (browse-kill-ring-preview-update (point-min))
-            ;; Local post-command-hook, only happens in the *Kill
-            ;; Ring* buffer
-            (add-hook 'post-command-hook 'browse-kill-ring-preview-update nil t)
+            (when browse-kill-ring-show-preview
+              (browse-kill-ring-preview-update (point-min))
+              ;; Local post-command-hook, only happens in the *Kill
+              ;; Ring* buffer
+              (add-hook 'post-command-hook
+                        'browse-kill-ring-preview-update nil t))
 ;; Code from Michael Slass <mikesl@wrq.com>
             (message
              (let ((entry (if (= 1 (length kill-ring)) "entry" "entries")))


### PR DESCRIPTION
Support for turning off the preview is currently broken, there's use of
browse-kill-ring-preview-overlay, and calls to
browse-kill-ring-preview-update.  This avoids the problem code when the
preview is turned off.
