### PR TITLE
Fixes issue when inserting with two frames/windows open.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-08-21 Andrew Burgess <andrew.burgess@embecosm.com>
+	Adjust mechanism used to restore buffer and window before
+	inserting items from the `kill-ring', this should resolve issues
+	when there are multiple frames or windows open onto the same
+	buffer with different values for point.
+
 2014-08-20 Andrew Burgess <andrew.burgess@embecosm.com>
 	Added variable `browse-kill-ring-highlight-inserted-item-style'
 	which selects the style to use when highlighting the inserted kill


### PR DESCRIPTION
The following issues should be resolved by this commit.

(1) In a single frame, create 3 windows within the frame, with every
frame open on the same window.  Make sure that the point is at a
different location within every window.  Place some items into the
`kill-ring`.  Lets call the windows A, B, & C.  Select window A and use
`browse-kill-ring`, and then use `browse-kill-ring-insert-and-quit`.

What you should see is that in window A the item has been inserted, and
the point has moved to the end of the inserted text.  When the `*Kill
Ring*` buffer opened up, it will have hidden one of the windows B or C,
in the window that was hidden the point should be unchanged.  In the
third window, the one that was not hidden when the `*Kill Ring*` buffer
appeared, you should notice that the point has moved to the same
location as in window A.  This is a bug, the point should not have
changed in the third window, after this patch the point will not have
changed in the third window.

(2) Create 2 frames both frames should be open on the same buffer.
Ensure that the value of point is different in each frame.  Place some
values into the `kill-ring`.  Lets call the frames A and B.  In frame A
use `browse-kill-ring`, then use `browse-kill-ring-insert-and-quit`.

You should see that the items was inserted at the point value of B
instead of A as it should have been.  The point value of A will have
changed to be after the inserted text.  This behaviour is wrong, after
this patch the item will be inserted at the point value of A, the point
in A will still be updated to be after the inserted item, the point
value of B will be unchanged.

(3) In a single frame on a single buffer place an item in the
`kill-ring`.  Ensure the point is NOT at the end of the buffer, now use
`browse-kill-ring`, then use `browse-kill-ring-append-insert-and-quit`.

You should see that the item is inserted at the end of the buffer (as
expected) and the point has moved to the end of the buffer.  It is not
obvious that this is a bug, however, inspection of
`browse-kill-ring-do-append-insert` shows a use of `save-excursion` that
suggests to me that point is not supposed to be changed by the append.
After this commit the item is still inserted at the end of the buffer,
but the point is restored to its original position.

(4) Same as previous but with `browse-kill-ring-prepend-insert-and-quit`.
