### PR TITLE
Add header-line to the buffer for editing kill-ring items.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2014-08-26 Andrew Burgess <andrew.burgess@embecosm.com>
+	When editing entries in the `kill-ring' place a header line in the
+	edit buffer with a short key guide.  Kill the edit buffer when
+	editing is finished rather than just burying it.  Add an abort key
+	mapping to allow the edit buffer to be closed without saving the
+	changes.
+
 2014-08-25 Andrew Burgess <andrew.burgess@embecosm.com>
 	Highlighting of the current entry in the *Kill Ring* buffer now
 	works with manual point movement rather than just with the

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -727,8 +727,10 @@ You most likely do not want to call `browse-kill-ring-edit-mode'
 directly; use `browse-kill-ring' instead.
 
 \\{browse-kill-ring-edit-mode-map}"
-  (define-key browse-kill-ring-edit-mode-map (kbd "C-c C-c")
-    'browse-kill-ring-edit-finish))
+  (define-key browse-kill-ring-edit-mode-map
+    (kbd "C-c C-c") 'browse-kill-ring-edit-finish)
+  (define-key browse-kill-ring-edit-mode-map
+    (kbd "C-c C-k") 'browse-kill-ring-edit-abort))
 
 (defvar browse-kill-ring-edit-target nil)
 (make-variable-buffer-local 'browse-kill-ring-edit-target)
@@ -751,9 +753,11 @@ directly; use `browse-kill-ring' instead.
       (goto-char (point-min))
       (browse-kill-ring-resize-window)
       (browse-kill-ring-edit-mode)
-      (message "%s"
-               (substitute-command-keys
-                "Use \\[browse-kill-ring-edit-finish] to finish editing."))
+      (setq header-line-format
+	    '(:eval
+	      (substitute-command-keys
+	       "Edit, then \\[browse-kill-ring-edit-finish] to \
+update entry and quit -- \\[browse-kill-ring-edit-abort] to abort.")))
       (setq browse-kill-ring-edit-target target-cell))))
 
 (defun browse-kill-ring-edit-finish ()
@@ -763,7 +767,20 @@ directly; use `browse-kill-ring' instead.
       (setcar browse-kill-ring-edit-target (buffer-string))
     (when (y-or-n-p "The item has been deleted; add to front? ")
       (push (buffer-string) kill-ring)))
-  (bury-buffer)
+  (kill-buffer)
+  ;; The user might have rearranged the windows
+  (when (eq major-mode 'browse-kill-ring-mode)
+    (browse-kill-ring-setup (current-buffer)
+                            browse-kill-ring-original-buffer
+                            browse-kill-ring-original-window
+                            nil
+                            browse-kill-ring-original-window-config)
+    (browse-kill-ring-resize-window)))
+
+(defun browse-kill-ring-edit-abort ()
+  "Abort the edit of the `kill-ring' item."
+  (interactive)
+  (kill-buffer)
   ;; The user might have rearranged the windows
   (when (eq major-mode 'browse-kill-ring-mode)
     (browse-kill-ring-setup (current-buffer)


### PR DESCRIPTION
When editing items in the `kill-ring' place a header line at the top of
the edit buffer containing a brief description of key bindings, this
replaces the current message containing the key binding advice.

This patch also adds an abort key binding which closes the edit buffer
without saving any changes back to the `kill-ring'.

Finally, this patch kills the edit buffer when the user finishes editing
rather than just burying it, there seems little point keeping the buffer
around once the user has finished with it.

ChangeLog:

```
When editing entries in the `kill-ring' place a header line in the
edit buffer with a short key guide.  Kill the edit buffer when
editing is finished rather than just burying it.  Add an abort key
mapping to allow the edit buffer to be closed without saving the
changes.
```
