### PR TITLE
Disable preview overlay before inserting.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
+	Disable the preview overlay before inserting the item from the
+	`kill-ring', then reenable once the item has been inserted, moving
+	the preview as appropriate, this ensures that when inserting
+	multiple items the preview continues to be useful.
+
+2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
 	Adjust mechanism used to restore buffer and window before
 	inserting items from the `kill-ring', this should resolve issues
 	when there are multiple frames or windows open onto the same


### PR DESCRIPTION
When inserting multiple items from the `kill-ring' using
`browse-kill-ring-insert', the point is adjusted after each insert, the
preview however, remains at the original point location, this is not
great as it makes the preview less useful.

A second issue with the existing preview is that it remains in place
until after the insert is complete, only being deleted as part of the
`browse-kill-ring-quit', if the preview is combined with highlighting
the item just inserted, then the preview AND the inserted item are both
present in the users buffer for a short while, this is can be confusing,
and can cause unneeded scrolling of the window.

This commit fixes these issues by removing the preview overlay before
inserting the item into the original buffer, and then restoring the
preview in an updated location if the user is not about to quit
`browse-kill-ring'.
