### PR TITLE
Improve deleting of the last item in kill-ring.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
+	When deleting the last item in the *Kill Ring* buffer, also delete
+	the preceding separator.
+
+2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
 	When editing entries in the `kill-ring' place a header line in the
 	edit buffer with a short key guide.  Kill the edit buffer when
 	editing is finished rather than just burying it.  Add an abort key

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -486,13 +486,23 @@ of the *Kill Ring*."
       (setq buffer-read-only nil)
       (delete-region (overlay-start over) (1+ (overlay-end over)))
       (setq kill-ring (delete target kill-ring))
-      (when (get-text-property (point) 'browse-kill-ring-extra)
+      (cond
+       ;; Don't try to delete anything else in an empty buffer.
+       ((and (bobp) (eobp)) t)
+       ;; The last entry was deleted, remove the preceeding separator.
+       ((eobp)
+        (progn
+          (browse-kill-ring-forward -1)
+          (let ((over (browse-kill-ring-target-overlay-at (point))))
+            (delete-region (1+ (overlay-end over)) (point-max)))))
+       ;; Deleted a middle entry, delete following separator.
+       ((get-text-property (point) 'browse-kill-ring-extra)
         (let ((prev (previous-single-property-change (point) 'browse-kill-ring-extra))
               (next (next-single-property-change (point) 'browse-kill-ring-extra)))
           (when prev (incf prev))
           (when next (incf next))
           (delete-region (or prev (point-min)) (or next (point-max))))))
-    (setq buffer-read-only t))
+    (setq buffer-read-only t)))
   (browse-kill-ring-resize-window)
   (browse-kill-ring-forward 0))
 


### PR DESCRIPTION
When deleting the last item in the `*Kill Ring*` buffer using `browse-kill-ring-delete` make sure that the separator before the item is also deleted.
