### PR TITLE
Reselect `kill-ring` item after editing.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
+	After editing entries from the `*Kill Ring*' reselect the item in
+	the `*Kill Ring*' buffer.
+
+2014-09-01 Andrew Burgess <andrew.burgess@embecosm.com>
 	Factor out code from `browse-kill-ring' to find a matching entry
 	in the `kill-ring' creating `browse-kill-ring-find-entry', this
 	will be used in a later commit.  Should be no user visible changes

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -770,32 +770,39 @@ update entry and quit -- \\[browse-kill-ring-edit-abort] to abort.")))
 (defun browse-kill-ring-edit-finish ()
   "Commit the changes to the `kill-ring'."
   (interactive)
-  (if browse-kill-ring-edit-target
-      (setcar browse-kill-ring-edit-target (buffer-string))
-    (when (y-or-n-p "The item has been deleted; add to front? ")
-      (push (buffer-string) kill-ring)))
-  (kill-buffer)
-  ;; The user might have rearranged the windows
-  (when (eq major-mode 'browse-kill-ring-mode)
-    (browse-kill-ring-setup (current-buffer)
-                            browse-kill-ring-original-buffer
-                            browse-kill-ring-original-window
-                            nil
-                            browse-kill-ring-original-window-config)
-    (browse-kill-ring-resize-window)))
+  (let ((updated-entry (buffer-string)))
+    (if browse-kill-ring-edit-target
+        (setcar browse-kill-ring-edit-target updated-entry)
+      (when (y-or-n-p "The item has been deleted; add to front? ")
+        (push updated-entry kill-ring)))
+    (kill-buffer)
+    ;; The user might have rearranged the windows
+    (when (eq major-mode 'browse-kill-ring-mode)
+      (browse-kill-ring-setup (current-buffer)
+                              browse-kill-ring-original-buffer
+                              browse-kill-ring-original-window
+                              nil
+                              browse-kill-ring-original-window-config)
+      (browse-kill-ring-resize-window)
+      (browse-kill-ring-find-entry updated-entry))))
 
 (defun browse-kill-ring-edit-abort ()
   "Abort the edit of the `kill-ring' item."
   (interactive)
-  (kill-buffer)
-  ;; The user might have rearranged the windows
-  (when (eq major-mode 'browse-kill-ring-mode)
-    (browse-kill-ring-setup (current-buffer)
-                            browse-kill-ring-original-buffer
-                            browse-kill-ring-original-window
-                            nil
-                            browse-kill-ring-original-window-config)
-    (browse-kill-ring-resize-window)))
+  (let ((current-entry (if browse-kill-ring-edit-target
+                           (car browse-kill-ring-edit-target)
+                         nil)))
+    (kill-buffer)
+    ;; The user might have rearranged the windows
+    (when (eq major-mode 'browse-kill-ring-mode)
+      (browse-kill-ring-setup (current-buffer)
+                              browse-kill-ring-original-buffer
+                              browse-kill-ring-original-window
+                              nil
+                              browse-kill-ring-original-window-config)
+      (browse-kill-ring-resize-window))
+    (if current-entry
+        (browse-kill-ring-find-entry current-entry))))
 
 (defmacro browse-kill-ring-add-overlays-for (item &rest body)
   (let ((beg (gensym "browse-kill-ring-add-overlays-"))


### PR DESCRIPTION
After editing an item in the `*Kill Ring*` buffer, reselect the item once the edit is either finished or aborted.  Compared to the current behaviour, where the selection returns to the first item, this new behaviour feels like a better user experience.
