### PR TITLE
Use a kill-buffer-hook to ensure that the preview is removed.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 2014-09-03 Andrew Burgess <andrew.burgess@embecosm.com>
+	Register a `kill-buffer-hook' to ensure that the preview is
+	removed even if the `*Kill Ring*' bufer is killed in an unexpected
+	way, that is, by not calling `browse-kill-ring-quit' but calling
+	`kill-buffer' directly.
+
+2014-09-03 Andrew Burgess <andrew.burgess@embecosm.com>
 	When editing an item from the `kill-ring', if the preview is
 	turned on, then update the preview live while the edit is being
 	made.

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -661,8 +661,7 @@ entry."
 (defun browse-kill-ring-quit ()
   "Take the action specified by `browse-kill-ring-quit-action'."
   (interactive)
-  (when browse-kill-ring-preview-overlay
-    (delete-overlay browse-kill-ring-preview-overlay))
+  (browse-kill-ring-cleanup-on-exit)
   (case browse-kill-ring-quit-action
     (save-and-restore
       (if (< emacs-major-version 24)
@@ -990,6 +989,15 @@ update the preview in the original buffer."
           (setq i (1- i)))))
     result-yank-pointer))
 
+(defun browse-kill-ring-cleanup-on-exit ()
+  "Function called when the user is finished with `browse-kill-ring'.
+This function performs any cleanup that is required when the user
+has finished interacting with the `*Kill Ring*' buffer.  For now
+the only cleanup performed is to remove the preview overlay, if
+it's turned on."
+  (when browse-kill-ring-preview-overlay
+    (delete-overlay browse-kill-ring-preview-overlay)))
+
 (defun browse-kill-ring-setup (kill-buf orig-buf window &optional regexp window-config)
   (setq browse-kill-ring-this-buffer-replace-yanked-text
         (and
@@ -1063,6 +1071,9 @@ update the preview in the original buffer."
               ;; Ring* buffer
               (add-hook 'post-command-hook
                         'browse-kill-ring-preview-update-by-position
+                        nil t)
+              (add-hook 'kill-buffer-hook
+                        'browse-kill-ring-cleanup-on-exit
                         nil t))
             (when browse-kill-ring-highlight-current-entry
               (add-hook 'post-command-hook


### PR DESCRIPTION
Previously, if the `*Kill Ring*` buffer is killed in by calling `kill-buffer` directly, rather than `browse-kill-ring-quit` then the preview would be left active.  After this patch the preview will be removed even when `kill-buffer` is used.
