### PR TITLE
Delete items that are edited to the empty string.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-09-11 Andrew Burgess <andrew.burgess@embecosm.com>
+	When editing entries from the *Kill Ring* buffer, reducing the
+	entry to the empty string will cause the item to be deleted from
+	the kill-ring once the edit is complete.
+
 2014-09-08 Andrew Burgess <andrew.burgess@embecosm.com>
 	Fix bug in `browse-kill-ring-occur' due to change in parameters of
 	`browse-kill-ring-setup'.


### PR DESCRIPTION
This replaces pull request #39, and does pretty much the same thing: 

> When using the edit feature of browse-kill-ring, if an item is edited to the empty string then it is deleted from the `kill-ring` and the display is updated.

The improvement in this version is related to the selection of the next item after the previous one is deleted, these selection policy should be the same as if the user had deleted the item with `browse-kill-ring-delete`.  There is still an issue relating to duplicate entries in the `kill-ring`, if there are duplicate entries then the wrong entry may be reselected after the delete, but that is a long standing browse-kill-ring bug, not specifically related to this patch.
