### PR TITLE
Prevent ...-edit-finish being using in non edit buffer.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-09-12 Andrew Burgess <andrew.burgess@embecosm.com>
+	Calling `browse-kill-ring-edit-finish' in a buffer that is not an
+	edit buffer will now given an error.
+
 2014-09-08 Andrew Burgess <andrew.burgess@embecosm.com>
 	Fix bug in `browse-kill-ring-occur' due to change in parameters of
 	`browse-kill-ring-setup'.

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -784,11 +784,10 @@ update entry and quit -- \\[browse-kill-ring-edit-abort] to abort.")))
 (defun browse-kill-ring-edit-finish ()
   "Commit the changes to the `kill-ring'."
   (interactive)
+  (unless browse-kill-ring-edit-target
+    (error "Not a browse-kill-ring edit buffer"))
   (let ((updated-entry (buffer-string)))
-    (if browse-kill-ring-edit-target
-        (setcar browse-kill-ring-edit-target updated-entry)
-      (when (y-or-n-p "The item has been deleted; add to front? ")
-        (push updated-entry kill-ring)))
+    (setcar browse-kill-ring-edit-target updated-entry)
     (kill-buffer)
     ;; The user might have rearranged the windows
     (when (eq major-mode 'browse-kill-ring-mode)


### PR DESCRIPTION
The change description:

> Calling `browse-kill-ring-edit-finish` in a buffer that is not a browse-kill-ring edit buffer will now give an error, this relies on `browse-kill-ring-edit-target` always being set in a browse-kill-ring edit buffer, which should always be true; `browse-kill-ring-edit` will throw an error if `browse-kill-ring-edit-target` can't be set.

This change was mentioned in a comment on PR #39, at the time I thought that this code was required, I made this claim because I was (still am) sure that I'd seen the question `"The item has been deleted; add to front? "` asked.  However, going back, I've been unable to cause that condition to trigger, except by calling `browse-kill-ring-edit-finish` in a buffer that was not the edit buffer, which does not feel like something that should be supported.

So, I think this change could be merged, but equally, if someone would like to explain why the code I've removed is actually important, and how to trigger it, then I'm happy to drop this PR, and create another one that just adds a comment explaining things.