### PR TITLE
Support non browse-kill-ring overlays in the *Kill Ring* buffer.

### DIFF
--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -625,17 +625,17 @@ entry."
          current-prefix-arg))
   (let ((orig (point)))
     (browse-kill-ring-forward (if backwards -1 1))
-    (let ((overs (overlays-at (point))))
-      (while (and overs
+    (let ((over (browse-kill-ring-target-overlay-at (point) t)))
+      (while (and over
                   (not (if backwards (bobp) (eobp)))
                   (not (string-match regexp
-                                     (overlay-get (car overs)
+                                     (overlay-get over
                                                   'browse-kill-ring-target))))
         (browse-kill-ring-forward (if backwards -1 1))
-        (setq overs (overlays-at (point))))
-      (unless (and overs
+        (setq over (browse-kill-ring-target-overlay-at (point) t)))
+      (unless (and over
                    (string-match regexp
-                                 (overlay-get (car overs)
+                                 (overlay-get over
                                               'browse-kill-ring-target)))
         (progn
           (goto-char orig)


### PR DESCRIPTION
This should fix issue https://github.com/browse-kill-ring/browse-kill-ring/issues/46 which is caused by `global-linum-mode` adding additional overlays into the `*Kill Ring*` buffer.  There were a few places in the code where we called `overlays-at` and assumed that the only overlays we would ever get back would be from `browse-kill-ring`.  This patch series removes all of these assumptions, one function at a time, and instead uses the already existing `browse-kill-ring-target-overlay-at` function, which finds the correct overlay.
