### PR TITLE
Unify common code after `browse-kill-ring-edit'.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-01-02 Andrew Burgess <andrew.burgess@embecosm.com>
+	Unify tail of `browse-kill-ring-finish' and
+	`browse-kill-ring-abort' to increase code reuse.  Improve use of
+	`brose-kill-ring-edit-target' to track when the user is making an
+	edit.
+
 2014-11-04 Toon Claes <toon@tonotdo.com>
 	v2.0 release:
 	Legacy code is removed, README is converted and

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -765,42 +765,52 @@ update entry and quit -- \\[browse-kill-ring-edit-abort] to abort.")))
                 'browse-kill-ring-preview-update-for-edit nil t))
     (setq browse-kill-ring-edit-target target-cell)))
 
+(defun browse-kill-ring-edit-finalise (entry)
+  "Common code called after `browse-kill-ring-edit' has finished
+
+This common code is called after `browse-kill-ring-edit-finish'
+and `browse-kill-ring-edit-abort'.  It kills the edit buffer, and
+reselects ENTRY in the `*Kill Ring*' buffer."
+  ;; Kill the edit buffer.  Maybe we should do more to keep track of
+  ;; the edit buffer so we can kill it even if we're not in it?
+  (when (eq major-mode 'browse-kill-ring-edit-mode)
+    (kill-buffer))
+  ;; The user might have rearranged the windows
+  (when (eq major-mode 'browse-kill-ring-mode)
+    (browse-kill-ring-setup (current-buffer)
+                            browse-kill-ring-original-buffer
+                            browse-kill-ring-original-window
+                            nil
+                            browse-kill-ring-original-window-config)
+    (browse-kill-ring-resize-window)
+    (when entry
+      (browse-kill-ring-find-entry entry))))
+
 (defun browse-kill-ring-edit-finish ()
-  "Commit the changes to the `kill-ring'."
+  "Commit the edit changes to the `kill-ring'."
   (interactive)
+  (unless browse-kill-ring-edit-target
+    (error "Not editing a kill-ring item"))
   (let* ((updated-entry (buffer-string))
          (delete-entry? (string= updated-entry ""))
+         (current-entry browse-kill-ring-edit-target)
          (select-entry nil))
-    (if browse-kill-ring-edit-target
-        (if delete-entry?
-            ;; Find the previous entry in the list to select, then
-            ;; delete the entry that was just edited to empty.
-            (progn
-              (setq select-entry
-                    (cadr browse-kill-ring-edit-target))
-              (setq kill-ring
-                    (delete (car browse-kill-ring-edit-target) kill-ring))
-              (unless select-entry
-                (setq select-entry (car (last kill-ring)))))
-          ;; Update the entry that was just edited, and arrange to
-          ;; select it.
-          (setcar browse-kill-ring-edit-target updated-entry)
-          (setq select-entry updated-entry))
-      (unless delete-entry?
-        (when (y-or-n-p "The item has been deleted; add to front? ")
-          (push updated-entry kill-ring)
-          (setq select-entry updated-entry))))
-    (kill-buffer)
-    ;; The user might have rearranged the windows
-    (when (eq major-mode 'browse-kill-ring-mode)
-      (browse-kill-ring-setup (current-buffer)
-                              browse-kill-ring-original-buffer
-                              browse-kill-ring-original-window
-                              nil
-                              browse-kill-ring-original-window-config)
-      (browse-kill-ring-resize-window)
-      (when select-entry
-        (browse-kill-ring-find-entry select-entry)))))
+    (setq browse-kill-ring-edit-target nil)
+    (if delete-entry?
+        ;; Find the previous entry in the list to select, then
+        ;; delete the entry that was just edited to empty.
+        (progn
+          (setq select-entry
+                (cadr current-entry))
+          (setq kill-ring
+                (delete (car current-entry) kill-ring))
+          (unless select-entry
+            (setq select-entry (car (last kill-ring)))))
+      ;; Update the entry that was just edited, and arrange to select
+      ;; it.
+      (setcar current-entry updated-entry)
+      (setq select-entry updated-entry))
+    (browse-kill-ring-edit-finalise select-entry)))
 
 (defun browse-kill-ring-edit-abort ()
   "Abort the edit of the `kill-ring' item."
@@ -808,17 +818,8 @@ update entry and quit -- \\[browse-kill-ring-edit-abort] to abort.")))
   (let ((current-entry (if browse-kill-ring-edit-target
                            (car browse-kill-ring-edit-target)
                          nil)))
-    (kill-buffer)
-    ;; The user might have rearranged the windows
-    (when (eq major-mode 'browse-kill-ring-mode)
-      (browse-kill-ring-setup (current-buffer)
-                              browse-kill-ring-original-buffer
-                              browse-kill-ring-original-window
-                              nil
-                              browse-kill-ring-original-window-config)
-      (browse-kill-ring-resize-window))
-    (if current-entry
-        (browse-kill-ring-find-entry current-entry))))
+    (setq browse-kill-ring-edit-target nil)
+    (browse-kill-ring-edit-finalise current-entry)))
 
 (defmacro browse-kill-ring-add-overlays-for (item &rest body)
   (let ((beg (gensym "browse-kill-ring-add-overlays-"))


### PR DESCRIPTION
This patch unifies common code from `browse-kill-ring-finish' and `browse-kill-ring-abort', and adds protection so that we only kill the edit buffer if it's in the correct mode (so we can be reasonably sure that it really is the edit buffer).

I've made the `browse-kill-ring-edit-target' variable track when the user is editing an entry in the `kill-ring', resetting it's value to nil after the edit is complete.  The variable can then now be used to tell if calling `browse-kill-ring-edit-finish' is correct or not.