### PR TITLE
Remove browse-kill-ring-no-duplicates.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-04-27 Andrew Burgess <andrew.burgess@embecosm.com>
+	Remove `browse-kill-ring-no-duplicates'.  This functionality was
+	never related to browsing the kill-ring, and would be better moved
+	in to a different package.
+
 2014-11-04 Toon Claes <toon@tonotdo.com>
 	v2.0 release:
 	Legacy code is removed, README is converted and

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -175,38 +175,6 @@ if non-nil, then display leftmost(last) duplicate items in `kill-ring'."
   :type 'boolean
   :group 'browse-kill-ring)
 
-(defadvice kill-new (around browse-kill-ring-no-kill-new-duplicates)
-  "An advice for not adding duplicate elements to `kill-ring'.
-Even after being \"activated\", this advice will only modify the
-behavior of `kill-new' when `browse-kill-ring-no-duplicates'
-is non-nil."
-  (if browse-kill-ring-no-duplicates
-      (setq kill-ring (delete (ad-get-arg 0) kill-ring)))
-  ad-do-it)
-
-(defcustom browse-kill-ring-no-duplicates nil
-  "If non-nil, then the `b-k-r-no-kill-new-duplicates' advice will operate.
-This means that duplicate entries won't be added to the `kill-ring'
-when you call `kill-new'.
-
-If you set this variable via customize, the advice will be activated
-or deactivated automatically.  Otherwise, to enable the advice, add
-
-B (ad-enable-advice 'kill-new 'around 'browse-kill-ring-no-kill-new-duplicates)
- (ad-activate 'kill-new)
-
-to your init file."
-  :type 'boolean
-  :set (lambda (symbol value)
-         (set symbol value)
-         (if value
-             (ad-enable-advice 'kill-new 'around
-                               'browse-kill-ring-no-kill-new-duplicates)
-           (ad-disable-advice 'kill-new 'around
-                              'browse-kill-ring-no-kill-new-duplicates))
-         (ad-activate 'kill-new))
-  :group 'browse-kill-ring)
-
 (defcustom browse-kill-ring-depropertize nil
   "If non-nil, remove text properties from `kill-ring' items.
 This only changes the items for display and insertion from


### PR DESCRIPTION
The `browse-kill-ring-no-duplicates` functionality is not related to browsing the kill-ring, but is instead about controlling what is placed in to the kill-ring.

This functionality, if it is wanted at all, should be moved into a new package, the browse-kill-ring package should focus on its core task rather than collecting random `kill-ring` related functionality.