### PR TITLE
Improve browse-kill-ring-occur

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2015-05-18 Andrew Burgess <andrew.burgess@embecosm.com>
+	Restore the mode name to "Kill Ring" if the filter regexp is
+	removed.
+
+2015-05-18 Andrew Burgess <andrew.burgess@embecosm.com>
 	The default for `browse-kill-ring-occur' is now to remove the
 	regexp that is currently in place, restoring all item in the
 	kill-ring to the display.  Previous regexp are still available in

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-05-18 Andrew Burgess <andrew.burgess@embecosm.com>
+	The default for `browse-kill-ring-occur' is now to remove the
+	regexp that is currently in place, restoring all item in the
+	kill-ring to the display.  Previous regexp are still available in
+	the history ring if needed.
+
 2015-04-27 Andrew Burgess <andrew.burgess@embecosm.com>
 	Remove `browse-kill-ring-no-duplicates'.  This functionality was
 	never related to browsing the kill-ring, and would be better moved

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -1080,8 +1080,9 @@ it's turned on."
             (set-buffer-modified-p nil)
             (goto-char (point-min))
             (browse-kill-ring-forward 0)
-            (when regexp
-              (setq mode-name (concat "Kill Ring [" regexp "]")))
+            (setq mode-name (if regexp
+                                (concat "Kill Ring [" regexp "]")
+                              "Kill Ring"))
             (run-hooks 'browse-kill-ring-hook)))
       (progn
         (setq buffer-read-only t)))))

--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -567,11 +567,11 @@ case retun nil."
   (interactive "p")
   (browse-kill-ring-forward (- arg)))
 
-(defun browse-kill-ring-read-regexp (msg)
+(defun browse-kill-ring-read-regexp (msg &optional empty-is-nil-p)
   (let* ((default (car regexp-history))
          (input
           (read-from-minibuffer
-           (if default
+           (if (and default (not empty-is-nil-p))
                (format "%s for regexp (default `%s'): "
                        msg
                        default)
@@ -579,9 +579,10 @@ case retun nil."
            nil
            nil
            nil
-           'regexp-history)))
+           'regexp-history
+           (if empty-is-nil-p default nil))))
     (if (equal input "")
-        default
+        (if empty-is-nil-p nil default)
       input)))
 
 (defun browse-kill-ring-search-forward (regexp &optional backwards)
@@ -853,8 +854,8 @@ reselects ENTRY in the `*Kill Ring*' buffer."
 (defun browse-kill-ring-occur (regexp)
   "Display all `kill-ring' entries matching REGEXP."
   (interactive
-   (list
-    (browse-kill-ring-read-regexp "Display kill ring entries matching")))
+   (list (browse-kill-ring-read-regexp
+          "Display kill ring entries matching" t)))
   (assert (eq major-mode 'browse-kill-ring-mode))
   (browse-kill-ring-setup (current-buffer)
                           browse-kill-ring-original-buffer


### PR DESCRIPTION
These two patches change slightly the way that `browse-kill-ring-occur` works.  Previously, the first time you use the occur function to enter a regexp the kill-ring list would be filtered as you'd expect.

Now, the second time you use the occur function to enter a new filter regexp, this new regexp replaces the current one in effect.  However, there's no way to remove the regexp; the default if you enter the empty string is to reapply the current regexp.

I dislike this behaviour.  Under my proposed change, the default empty string will remove the currently active regexp filter, restoring the complete list of kill-ring items.  If the user wants to work with a previously entered regexp they can of course use the history ring at the regexp prompt.

The second commit in the series just ensures that the buffer name is correctly updated when the active regexp is removed.