### PR TITLE
explicitly (require 'cl)

### DIFF
--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -49,6 +49,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'cl)
 (require 'derived)
 
 (defgroup browse-kill-ring nil


### PR DESCRIPTION
On my Emacs 24.5.1, I got "Invalid function: assert" messages from browse-kill-ring because I hadn't required 'cl anywhere.

After requiring 'cl, browse-kill-ring installed and worked fine.

It seems like browse-kill-ring does require 'cl, but hadn't required it, maybe because 'cl is so commonly already required by something or other. But I think this addition will prevent problems like the one I had!