### PR TITLE
Fix warning about single quotes in docstrings

### DIFF
--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -290,8 +290,8 @@ well."
 
 (defun browse-kill-ring-insert-new (insert-action post-action &optional quit)
   "Insert the kill ring item at point into the last selected buffer.
-`insert-action' can be 'insert 'append 'prepend.
-`post-action' can be nil 'move 'delete.
+INSERT-ACTION can be \\='insert \\='append \\='prepend.
+POST-ACTION can be nil \\='move \\='delete.
 If optional argument QUIT is non-nil, close the *Kill Ring* buffer as
 well."
   (interactive "P")


### PR DESCRIPTION
* browse-kill-ring.el (browse-kill-ring-insert-new): Fix warning about wrong usage of unescaped single quotes in docstrings issued by Emacs 29.
Upcase the name of arguments.