### PR TITLE
Pacify compiler warning

### DIFF
--- a/browse-kill-ring.el
+++ b/browse-kill-ring.el
@@ -1073,9 +1073,10 @@ it's turned on."
               ;; display leftmost or rightmost duplicate.
               ;; if `browse-kill-ring-display-leftmost-duplicate' is t,
               ;; display leftmost(last) duplicate.
-              (cl-delete-duplicates items
-                                 :test #'equal
-                                 :from-end browse-kill-ring-display-leftmost-duplicate))
+              (setq items
+                    (cl-delete-duplicates items
+                                          :test #'equal
+                                          :from-end browse-kill-ring-display-leftmost-duplicate)))
             (when (stringp regexp)
               (setq items (delq nil
                                 (mapcar
@@ -1102,7 +1103,7 @@ it's turned on."
               (add-hook 'post-command-hook
                         'browse-kill-ring-update-highlighed-entry
                         nil t))
-;; Code from Michael Slass <mikesl@wrq.com>
+            ;; Code from Michael Slass <mikesl@wrq.com>
             (message
              (let ((entry (if (= 1 (length kill-ring)) "entry" "entries")))
                (concat
@@ -1115,7 +1116,7 @@ it's turned on."
                 (substitute-command-keys
                  (concat "    Type \\[browse-kill-ring-quit] to quit.  "
                          "\\[describe-mode] for help.")))))
-;; End code from Michael Slass <mikesl@wrq.com>
+            ;; End code from Michael Slass <mikesl@wrq.com>
             (set-buffer-modified-p nil)
             (goto-char (point-min))
             (browse-kill-ring-forward 0)


### PR DESCRIPTION
* browse-kill-ring.el (browse-kill-ring-setup): Store the return value of `cl-delete-duplicates' back in `items'.  This prevents the byte-compiler warning about 'value form call is unused'.

I hope you also don't mind the indentation of comments.